### PR TITLE
Feature remove init

### DIFF
--- a/earth_rover_localization/launch/er_localization_node.launch
+++ b/earth_rover_localization/launch/er_localization_node.launch
@@ -31,11 +31,12 @@
     <param name="broadcast_utm_transform" value="true"/>
     <param name="publish_filtered_gps" value="true"/>
     <param name="use_odometry_yaw" value="false"/>
-    <param name="wait_for_datum" value="true"/>
-      <rosparam param="datum">[53.4386604283, -0.932653757765, 0.0]</rosparam>    # Replace with desired Map origins. Check convergence value
+    <param name="wait_for_datum" value="false"/>
+      <!-- <rosparam param="datum">[53.4386604283, -0.932653757765, 0.0]</rosparam>    # Replace with desired Map origins. Check convergence value -->
 
     <remap from="/odometry/filtered" to="/odometry/filtered/global"/>
     <remap from="/gps/fix" to="/piksi_receiver/navsatfix_best_fix"/>
+    <remap from="/imu/data" to="/heading"/>
   </node>
 
  </launch>

--- a/earth_rover_localization/launch/er_localization_node.launch
+++ b/earth_rover_localization/launch/er_localization_node.launch
@@ -32,7 +32,6 @@
     <param name="publish_filtered_gps" value="true"/>
     <param name="use_odometry_yaw" value="false"/>
     <param name="wait_for_datum" value="false"/>
-      <!-- <rosparam param="datum">[53.4386604283, -0.932653757765, 0.0]</rosparam>    # Replace with desired Map origins. Check convergence value -->
 
     <remap from="/odometry/filtered" to="/odometry/filtered/global"/>
     <remap from="/gps/fix" to="/piksi_receiver/navsatfix_best_fix"/>

--- a/earth_rover_localization/launch/piksi_multi_rover_attitude.launch
+++ b/earth_rover_localization/launch/piksi_multi_rover_attitude.launch
@@ -11,9 +11,9 @@
   <!-- IP of a "pingable" device, used to check network status. -->
   <arg name="base_station_ip"             default="192.168.8.1"/>
   <!-- Enable/disable load of an origin position of ENU frame. -->
-  <arg name="load_enu_origin_from_file"   default="true"/>
+  <arg name="load_enu_origin_from_file"   default="false"/>
   <!-- Location of the file containing origin ENU frame, used if 'load_enu_origin_from_file' is true. -->
-  <arg name="enu_origin_file"             default="$(find earth_rover_localization)/cfg/enu_origin.yaml"/>
+  <!-- <arg name="enu_origin_file"             default="$(find earth_rover_localization)/cfg/enu_origin.yaml"/> -->
 
   <!-- Piksi Multi ROS driver node: rover mode -->
   <node pkg="piksi_multi_rtk" type="piksi_multi" name="piksi_attitude" output="screen" respawn="true">

--- a/earth_rover_localization/launch/piksi_multi_rover_attitude.launch
+++ b/earth_rover_localization/launch/piksi_multi_rover_attitude.launch
@@ -11,7 +11,7 @@
   <!-- IP of a "pingable" device, used to check network status. -->
   <arg name="base_station_ip"             default="192.168.8.1"/>
   <!-- Enable/disable load of an origin position of ENU frame. -->
-  <arg name="load_enu_origin_from_file"   default="true"/>
+  <arg name="load_enu_origin_from_file"   default="false"/>
   <!-- Location of the file containing origin ENU frame, used if 'load_enu_origin_from_file' is true. -->
   <arg name="enu_origin_file"             default="$(find earth_rover_localization)/cfg/enu_origin.yaml"/>
 
@@ -20,7 +20,6 @@
     <!-- Load default settings -->
     <rosparam file="$(find earth_rover_localization)/cfg/piksi_multi_driver_settings_rover_attitude.yaml"/>
 
-    <!-- Load enu origin from file -->
     <rosparam file="$(arg enu_origin_file)"   if="$(arg load_enu_origin_from_file)"/>
 
     <!-- Overwrite settings -->

--- a/earth_rover_localization/launch/piksi_multi_rover_reference.launch
+++ b/earth_rover_localization/launch/piksi_multi_rover_reference.launch
@@ -11,9 +11,9 @@
   <!-- IP of a "pingable" device, used to check network status. -->
   <arg name="base_station_ip"             default="192.168.8.1"/>
   <!-- Enable/disable load of an origin position of ENU frame. -->
-  <arg name="load_enu_origin_from_file"   default="true"/>
+  <arg name="load_enu_origin_from_file"   default="false"/>
   <!-- Location of the file containing origin ENU frame, used if 'load_enu_origin_from_file' is true. -->
-  <arg name="enu_origin_file"             default="$(find earth_rover_localization)/cfg/enu_origin.yaml"/>
+  <!-- <arg name="enu_origin_file"             default="$(find earth_rover_localization)/cfg/enu_origin.yaml"/> -->
 
   <!-- Piksi Multi ROS driver node: rover mode -->
   <node pkg="piksi_multi_rtk" type="piksi_multi" name="piksi_receiver" output="screen" respawn="true">

--- a/earth_rover_localization/launch/piksi_multi_rover_reference.launch
+++ b/earth_rover_localization/launch/piksi_multi_rover_reference.launch
@@ -11,7 +11,7 @@
   <!-- IP of a "pingable" device, used to check network status. -->
   <arg name="base_station_ip"             default="192.168.8.1"/>
   <!-- Enable/disable load of an origin position of ENU frame. -->
-  <arg name="load_enu_origin_from_file"   default="true"/>
+  <arg name="load_enu_origin_from_file"   default="false"/>
   <!-- Location of the file containing origin ENU frame, used if 'load_enu_origin_from_file' is true. -->
   <arg name="enu_origin_file"             default="$(find earth_rover_localization)/cfg/enu_origin.yaml"/>
 


### PR DESCRIPTION
Removed initial datum on localization launch files. Now it uses the first RTK estimation as the initial datum automatically.